### PR TITLE
feat(add): get entry text directly from arguments without opening an editor.

### DIFF
--- a/src/bin/diary/commands/add.rs
+++ b/src/bin/diary/commands/add.rs
@@ -16,11 +16,23 @@ pub fn cli() -> Command {
                 .value_name("TAG")
                 .help("Add a tag above the entry text."),
         )
+        .arg(
+            Arg::new("content")
+                .num_args(0..)
+                .value_name("CONTENT")
+                .help("entry text"),
+        )
 }
 
 fn args_to_add_opts(args: &ArgMatches) -> AddOptions {
     let tag = args.get_one::<String>("tag").cloned();
-    AddOptions { tag }
+    let content = args.get_many::<String>("content").map(|values_ref| {
+        values_ref
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>()
+            .join(" ")
+    });
+    AddOptions { tag, content }
 }
 
 pub fn exec(config_manager: ConfigManager, args: &ArgMatches) -> CliResult {


### PR DESCRIPTION
`diary add` will consider extra arguments as entry text if provided. For example, the command below:

    diary add save your tears

will add a new line "save your tears" into today's diary.